### PR TITLE
[Feat] Continuous Deployment 

### DIFF
--- a/client/src/pages/course/schedule/index.tsx
+++ b/client/src/pages/course/schedule/index.tsx
@@ -1,12 +1,10 @@
 import { Row, Select } from 'antd';
-import { withSession, PageLayout } from 'components';
-import withCourseData from 'components/withCourseData';
+import { PageLayout } from 'components';
 import { useState } from 'react';
-import { CoursePageProps } from 'services/models';
 import { TIMEZONES } from 'configs/timezones';
 import { ScheduleTable, ScheduleList, ScheduleCalendar } from 'components/Schedule';
 
-export function SchedulePage(props: CoursePageProps) {
+export function SchedulePage() {
   const [timeZone, setTimeZone] = useState(Intl.DateTimeFormat().resolvedOptions().timeZone);
 
   const [viewOfView, changeView] = useState('table');
@@ -53,11 +51,11 @@ export function SchedulePage(props: CoursePageProps) {
   };
 
   return (
-    <PageLayout title="Schedule" githubId={props.session.githubId} loading={false}>
+    <PageLayout title="Schedule" githubId={'props.session.githubId'} loading={false}>
       <ScheduleHeader />
       <ScheduleView />
     </PageLayout>
   );
 }
 
-export default withCourseData(withSession(SchedulePage));
+export default SchedulePage;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "./server/**"
   ],
   "scripts": {
-    "start": "concurrently \"cd ./client && npm run develop\" \"cd ./server && npm start\"",
+    "start:client": "cd ./client && yarn develop",
+    "start": "concurrently \"yarn start:client\" \"cd ./server && npm start\"",
     "format:fix": "prettier --write \"server/**/*.{ts,tsx}\" \"client/**/*.{ts,tsx,js}\" \"common/**/*.{ts,tsx,js}\"",
     "format:check": "prettier --check \"server/**/*.{ts,tsx}\" \"client/**/*.{ts,tsx,js}\" \"common/**/*.{ts,tsx,js}\"",
     "lint:js": "eslint . --ext .ts,.tsx",


### PR DESCRIPTION
I disable project API for schedule page to allow to see it without authorization by `/course/schedule`.
Also, for local running of project `yarn start:client` is enough now.